### PR TITLE
クイズリストの転送機能

### DIFF
--- a/packages/backend/src/routes/mylists.ts
+++ b/packages/backend/src/routes/mylists.ts
@@ -74,7 +74,7 @@ router.post('/', async (req, res) => {
         .selectFrom('mylists')
         .select(['name', 'mid'])
         .where('name', '=', listName)
-        .execute();
+        .executeTakeFirstOrThrow();
       
       const message = `${inserts.length} new mylists saved (user: ${userId})`;
       
@@ -162,10 +162,14 @@ router.delete('/quiz', async (req, res) => {
 
   try {
     await db.transaction().execute(async trx => {
+      const mylsitId = (await trx.selectFrom('mylists')
+      .select('id')
+      .where('mid', '=', mid)
+      .executeTakeFirstOrThrow())?.id
+
       const deletes = await trx.deleteFrom('mylists_quizzes')
-      .innerJoin('mylists', 'mylists.id', 'mylists_quizzes.mylist_id')
       .where(({ and, eb }) => and([
-        eb('mylists.mid', '=', mid),
+        eb('mylist_id', '=', mylsitId),
         eb('quiz_id', '=', quizId)
       ]))
       .executeTakeFirst();

--- a/packages/backend/src/routes/quizzes.ts
+++ b/packages/backend/src/routes/quizzes.ts
@@ -118,7 +118,8 @@ router.get('/:listName?', async (req: QuizRequest, res) => {
         ])
         : 
         between('histories.practiced', s, u)
-      ));
+      ))
+      .orderBy('histories.practiced desc');
     }
     else if (listName === 'create') {
       query = query

--- a/packages/frontend/src/components/CreateShowQuizList.tsx
+++ b/packages/frontend/src/components/CreateShowQuizList.tsx
@@ -1,18 +1,14 @@
-import { useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { Card, Center, DefaultProps, Grid, Group, Loader, Text } from "@mantine/core";
-import QuizControllBar from "@/components/QuizControllBar";
-import FilteringModal from "@/components/FilteringModal";
-import QuizShuffleButton from "@/components/QuizShuffleButton";
-import QuizPagination from "@/components/QuizPagination";
-import QuizList from "@/components/QuizList";
-import { KeywordOption, WorkbooksData } from "@/types";
+import { Card, DefaultProps, Group, Text } from "@mantine/core";
+import { WorkbooksData } from "@/types";
 import useQuizzes from "@/hooks/useQuizzes";
 import MylistDeleteModal from "@/components/MylistDeleteModal";
 import MylistEditModal from "@/components/MylistEditModal";
 import { useInput } from "@/hooks";
 import axios from "@/plugins/axios";
 import { useWorkbooks } from "@/hooks/useWorkbooks";
+import QuizViewer from "./QuizViewer";
 
 interface Props extends DefaultProps {
   wid: string,
@@ -21,52 +17,18 @@ interface Props extends DefaultProps {
 export default function({ wid }: Props) {
   const isAll = (wid == 'all');
   const navigator = useNavigate();
-  const [ activePage, setPage ] = useState(1);
-  const { quizzes, params, setParams } = useQuizzes({ perPage: 100, workbooks: isAll ? undefined : [ wid ] }, `/create`);
+  const { setParams } = useQuizzes("/create");
   const { workbooks, mutate } = useWorkbooks();
-
-  const size = !!quizzes && quizzes.length !== 0 ? quizzes[0].size : 0;
+  
   const workbooksName = isAll ? 'すべてのクイズ' : workbooks?.find(list => list.wid == wid)?.name;
-
   const [ newNameProps ] = useInput(workbooksName || '');
 
-  const toFilter = (
-    workbooks?: string[], 
-    levels?: string[], 
-    keyword?: string, 
-    keywordOption?: KeywordOption,
-    perPage?: number,
-  ) => {
-    setPage(1)
+  useEffect(() => {
     setParams({ 
-      ...params, 
-      page: 1, 
-      seed: undefined,
-      perPage,
-      workbooks, 
-      levels, 
-      keyword, 
-      keywordOption,
+      perPage: 100, 
+      workbooks: isAll ? undefined : [ wid ] 
     })
-  }
-
-  const toShuffle = (
-    seed: number
-  ) => {
-    setPage(1)
-    setParams({
-      ...params,
-      page: 1,
-      seed
-    })
-  }
-
-  const changePage = (
-    page: number
-  ) => {
-    setPage(page)
-    setParams({...params, page})
-  }
+  }, [])
 
   const toEdit = async () => {
     const newlist = await axios.put<WorkbooksData[]>('/workbooks/rename', {
@@ -86,71 +48,39 @@ export default function({ wid }: Props) {
     mutate(newlist);
   }
 
+  const CreateCard = () => (
+    <Card 
+      mb="xs"
+      w="100%" 
+      withBorder
+      sx={(theme) => ({
+        backgroundImage: theme.fn.gradient(),
+        color: theme.white,
+      })}
+    >
+      <Group position="apart">
+        <Text weight={700} size={25}>{ workbooksName }</Text>
+        {
+          !isAll ? <Group spacing="md">
+            <MylistEditModal
+              newNameProps={newNameProps}
+              onSave={toEdit}
+            />
+            <MylistDeleteModal
+              onDelete={toDelete}
+            />
+          </Group> : null
+        }
+      </Group>
+    </Card>
+  )
+
   return (
     <>
-      <QuizControllBar
-        height={!!quizzes ? 190 : 140}
-        total={size}
-        header={
-          <Card 
-            m={7} 
-            w="100%" 
-            withBorder
-            sx={(theme) => ({
-              backgroundImage: theme.fn.gradient(),
-              color: theme.white,
-            })}
-          >
-            <Group position="apart">
-              <Text weight={700} size={25}>{ workbooksName }</Text>
-              {
-                !isAll ? <Group spacing="md">
-                  <MylistEditModal
-                    newNameProps={newNameProps}
-                    onSave={toEdit}
-                  />
-                  <MylistDeleteModal
-                    onDelete={toDelete}
-                  />
-                </Group> : null
-              }
-            </Group>
-          </Card>
-        }
-        buttons={
-          <Group>
-            <FilteringModal
-              apply={toFilter}
-            />
-            <QuizShuffleButton
-              apply={toShuffle}
-            />
-          </Group>
-        }
-        pagination={
-          <Grid.Col span={12} mb="xs">
-            <Center>
-              <QuizPagination
-                page={activePage}
-                total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}
-                setPage={changePage}
-              />
-            </Center>
-          </Grid.Col>
-        }
+      <QuizViewer
+        path="/create"
+        headerCard={<CreateCard/>}
       />
-      {!!quizzes ? 
-        quizzes.length !== 0 ? 
-        <QuizList
-          quizzes={quizzes}
-        />
-        :
-        <Center>No data</Center>   
-      : 
-        <Center>
-          <Loader variant="dots"/>
-        </Center>
-      }
     </>
   )
 }

--- a/packages/frontend/src/components/FilteringWorkbook.tsx
+++ b/packages/frontend/src/components/FilteringWorkbook.tsx
@@ -1,7 +1,8 @@
 import React, { forwardRef  } from "react";
 import useSWR from "swr";
-import { Badge, DefaultProps, Group, MultiSelect } from "@mantine/core";
+import { DefaultProps, MultiSelect } from "@mantine/core";
 import { fetcher } from "@/fetchers";
+import { QuizWorkbookBadge } from "./QuizWorkbookBadge";
 
 interface WorkbookProps extends React.ComponentPropsWithoutRef<'div'> {
   wid: string,
@@ -23,14 +24,10 @@ interface FilteringWorkbookProps extends DefaultProps {
 const Item = forwardRef<HTMLDivElement, WorkbookProps>(
   ({ wid, label, color, ...others}: WorkbookProps, ref) => (
   <div ref={ref} {...others}>
-    <Group noWrap>
-      <Badge
-        variant="dot"
-        size="lg" 
-        radius="sm" 
-        color={color}
-      >{label}</Badge>
-    </Group>
+    <QuizWorkbookBadge
+      workbookName={label}
+      levelColor={color}
+    />
   </div>
 ))
 

--- a/packages/frontend/src/components/NavbarLink.tsx
+++ b/packages/frontend/src/components/NavbarLink.tsx
@@ -151,7 +151,7 @@ export default function ({
         <Collapse 
           in={opened}
         >
-          <ScrollArea h={200}>
+          <ScrollArea.Autosize mah={200}>
           {
             (links || []).map((l, idx) => 
               <Link 
@@ -164,7 +164,7 @@ export default function ({
               />
             )
           }
-          </ScrollArea>
+          </ScrollArea.Autosize>
         </Collapse> : null}
     </>
   );

--- a/packages/frontend/src/components/PracticeQuitModal.tsx
+++ b/packages/frontend/src/components/PracticeQuitModal.tsx
@@ -46,8 +46,6 @@ export default function PracticePauseModal({
         opened={opened} 
         onClose={() => close()}
         size={ isMobile ? 'xs' : 'md' }
-        pos="absolute"
-        left="-5%"
       >
         <Center>
           <Title>Pause</Title>

--- a/packages/frontend/src/components/PracticeQuizController.tsx
+++ b/packages/frontend/src/components/PracticeQuizController.tsx
@@ -1,6 +1,7 @@
 import { Button, Center, DefaultProps, Group } from "@mantine/core";
 import { IconChevronsRight, IconPlaystationCircle, IconX } from "@tabler/icons-react";
 import PracticeQuizButton from "./PracticeQuizButton";
+import { useState } from "react";
 
 interface Props extends DefaultProps {
   canPress?: boolean,
@@ -16,23 +17,35 @@ export function PracticeQuizController({
   onPress,
   ...others
 }: Props) {
+  const [ isPressed, setIsPressed ] = useState(false);
+
+  const pressed = () => {
+    onPress();
+    setIsPressed(true);
+  }
+
+  const judge = (judge: number) => {
+    onJudge(judge);
+    setIsPressed(false);
+  }
+  
   return (
     <>
       <Group position="center" grow {...others}>
-        <Button fullWidth size="xl" color="red" onClick={() => onJudge(1)} disabled={!canJudge}>
+        <Button fullWidth size="xl" color="red" onClick={() => judge(1)} disabled={!canJudge || !isPressed}>
           <IconPlaystationCircle/>
         </Button>
-        <Button fullWidth size="xl" color="gray" onClick={() => onJudge(2)} disabled={!canJudge}>
+        <Button fullWidth size="xl" color="gray" onClick={() => judge(2)} disabled={!canJudge || isPressed}>
           <IconChevronsRight/>
         </Button>
-        <Button fullWidth size="xl" color="blue" onClick={() => onJudge(0)} disabled={!canJudge}>
+        <Button fullWidth size="xl" color="blue" onClick={() => judge(0)} disabled={!canJudge || !isPressed}>
           <IconX/>
         </Button>
       </Group>
       <Center mt="sm">
         <PracticeQuizButton 
           width={280}
-          onClick={onPress}
+          onClick={pressed}
           disabled={!canPress}
         />
       </Center>

--- a/packages/frontend/src/components/PracticeQuizInfo.tsx
+++ b/packages/frontend/src/components/PracticeQuizInfo.tsx
@@ -1,5 +1,5 @@
 import { Card, DefaultProps, Group, Overlay, Text } from "@mantine/core";
-import { useMylistInfomations } from "@/hooks/useMylists";
+import { useMylists } from "@/hooks/useMylists";
 import { useIsMobile } from "@/contexts/isMobile";
 import QuizFavoriteButton from "./QuizFavoriteButton";
 import { QuizWorkbookBadge } from "./QuizWorkbookBadge";
@@ -28,7 +28,7 @@ export function PracticeQuizInfo({
   ...other
 }: Props) {
   const isMobile = useIsMobile();
-  const { mylists } = useMylistInfomations();
+  const { mylists } = useMylists();
 
   return (
     <Card p="sm" radius="sm" { ...other }>

--- a/packages/frontend/src/components/PracticeResultModal.tsx
+++ b/packages/frontend/src/components/PracticeResultModal.tsx
@@ -38,8 +38,6 @@ export default function PracticeResultModal({
       withCloseButton={false}
       closeOnClickOutside={false}
       size={isMobile ? 'xs' : 'md'}
-      pos="absolute"
-      left="-5%"
       {...others}
     >
       <Center>

--- a/packages/frontend/src/components/PracticeResultModal.tsx
+++ b/packages/frontend/src/components/PracticeResultModal.tsx
@@ -4,9 +4,12 @@ import { useIsMobile } from "@/contexts/isMobile";
 interface Props extends ModalProps {
   rightTotal: number,
   quizzesTotal: number,
-  onRetry: () => void,
-  onTry: () => void,
-  onQuit: () => void,
+  isTransfer: boolean,
+  canNext: boolean,
+  onRetry?: () => void,
+  onNext?: () => void,
+  onTry?: () => void,
+  onQuit?: () => void,
 }
 
 const defineMessage = (rate: number) => {
@@ -21,10 +24,13 @@ export default function PracticeResultModal({
   rightTotal,
   quizzesTotal,
   opened,
+  isTransfer,
+  canNext,
   onClose,
-  onRetry,
-  onTry,
-  onQuit,
+  onNext = () => {},
+  onRetry = () => {},
+  onTry = () => {},
+  onQuit = () => {},
   ...others
 }: Props) {
   const isMobile = useIsMobile();
@@ -47,7 +53,6 @@ export default function PracticeResultModal({
       <Stack
         spacing="md"
         h={300}
-        sx={(theme) => ({ backgroundColor: theme.colorScheme === 'dark' ? theme.colors.dark[8] : theme.colors.gray[0] })}
       >
         <Button
           size="lg"
@@ -56,15 +61,24 @@ export default function PracticeResultModal({
             onRetry();
             onClose();
           }}
-        >やりなおす</Button>
+        >同じ問題群でやりなおす</Button>
         <Button
           size="lg"
           color="blue.4"
+          disabled={isTransfer || !canNext}
+          onClick={() => {
+            onNext();
+          }}
+        >次の{quizzesTotal}問をする</Button>
+        <Button
+          size="lg"
+          color="orange"
+          disabled={isTransfer}
           onClick={() => {
             onTry();
             onClose();
-          }}>違う問題をする</Button>
-        {/* <Button size="lg" color="green">Searchに戻る</Button> */}
+          }}
+        >絞り込みをやり直す</Button>
         <Button
           size="lg"
           variant="outline"
@@ -72,7 +86,8 @@ export default function PracticeResultModal({
           onClick={() => {
             onQuit();
             onClose();
-          }}>クイズをやめる</Button>
+          }}
+        >クイズをやめる</Button>
       </Stack>
     </Modal>
   )

--- a/packages/frontend/src/components/PracticeSceneChanger.tsx
+++ b/packages/frontend/src/components/PracticeSceneChanger.tsx
@@ -37,7 +37,8 @@ export default function({
   const [ rightList, setRightList ] = useState<number[]>([]);
   const [ pressedWord, setPressedWord ] = useState(0);
   const quiz = !!quizzes ? quizzes[shuffledList[nowNumber]] : null;
-  const size = quizzes?.length || 0;
+  const maxQuizSize = quizzes?.length || 0;
+  const size = !!quizzes && !!quizzes.length ? quizzes[0].size : 0;
 
   const delay = useTimer(500, 100, () => setScene(1)); 
   const typewriter = useTypewriter(quiz?.question || "", 100, () => setScene(2));
@@ -123,11 +124,11 @@ export default function({
 
   const judgeQuiz = (judgement: number) => {
     record(judgement);
-    setNowNumber(nowNumber+1);
     
-    if (nowNumber >= (size-1)) {
+    if (nowNumber >= (maxQuizSize-1)) {
       setScene(5);
     } else { 
+      setNowNumber(nowNumber+1);
       setScene(0);
     }
   }
@@ -156,10 +157,20 @@ export default function({
       }
       <PracticeResultModal
         rightTotal={rightList.length}
-        quizzesTotal={size || 1}
+        quizzesTotal={maxQuizSize || 1}
+        isTransfer={isTransfer}
+        canNext={(quizzes && params?.perPage && params?.page) ? Math.ceil(size / params?.perPage) >= params?.page + 1 : false}
         opened={resulted}
         onClose={result.close}
         onRetry={() => setScene(0)}
+        onNext={() => {
+          setParams({
+            ...params,
+            page: (!!params?.page) ? params.page + 1 : 0
+          });
+          setScene(0);
+          setNowNumber(0);
+        }}
         onTry={filter.open}
         onQuit={() => navigator('/')}
       />
@@ -168,7 +179,7 @@ export default function({
           apply={toFilter}
           opened={filtering}
           onOpen={filter.open}
-          onClose={!!params ? filter.close : toFilter}
+          onClose={!!quizzes ? filter.close : toFilter}
         />
         <PracticeQuitModal
           onJudge={(j) => stopQuiz(j)}
@@ -176,7 +187,7 @@ export default function({
       </Group>
       <Text ta="center">
         <Text span fz={38} fw={700} >{ nowNumber+1 }</Text> 
-        <Text span fz={18} fw={500}> / { size }</Text>
+        <Text span fz={18} fw={500}> / { maxQuizSize }</Text>
       </Text>
       <Card p="md" radius="lg" withBorder>
         <PracticeTypewriteQuiz

--- a/packages/frontend/src/components/PracticeSceneChanger.tsx
+++ b/packages/frontend/src/components/PracticeSceneChanger.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Card, Group, Loader, Overlay, Text } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { KeywordOption, Quiz } from "@/types";
+import PracticeTypewriteQuiz from "@/components/PracticeTypewriteQuiz";
+import FilteringModal from "@/components/FilteringModal";
+import { PracticeQuizIntro } from "@/components/PracticeQuizIntro";
+import { PracticeQuizInfo } from "@/components/PracticeQuizInfo";
+import { PracticeQuizController } from "@/components/PracticeQuizController";
+import PracticeQuitModal from "@/components/PracticeQuitModal";
+import PracticeResultModal  from "@/components/PracticeResultModal";
+import axios from "@/plugins/axios";
+import { useTimer, useTypewriter } from "@/hooks";
+import useQuizzes from "@/hooks/useQuizzes";
+
+interface Props {
+  quizzes?: Quiz[],
+  shuffledList: number[],
+  isTransfer?: boolean,
+  onFilter?: () => void,
+}
+
+export default function({
+  quizzes,
+  shuffledList,
+  isTransfer = false,
+  onFilter = () => {},
+}: Props) {
+  const [ nowNumber, setNowNumber ] = useState(0);
+  const [ scene, setScene ] = useState(0);
+  const [ filtering, filter ] = useDisclosure(false);
+  const [ resulted, result ] = useDisclosure(false);
+  const navigator = useNavigate();
+
+  const { params, setParams } = useQuizzes();
+  const [ rightList, setRightList ] = useState<number[]>([]);
+  const [ pressedWord, setPressedWord ] = useState(0);
+  const quiz = !!quizzes ? quizzes[shuffledList[nowNumber]] : null;
+  const size = quizzes?.length || 0;
+
+  const delay = useTimer(500, 100, () => setScene(1)); 
+  const typewriter = useTypewriter(quiz?.question || "", 100, () => setScene(2));
+  const countdown = useTimer(4000, 1000, () => setScene(4)); 
+  const through = useTimer(3000, 100, () => setScene(4)); 
+
+  useEffect(() => {
+    switch(scene) {
+      case 0: 
+        delay.reset();
+        typewriter.reset();
+        countdown.reset();
+        through.reset();
+        result.close();
+        break;
+      case 1:
+        typewriter.start();
+        break;
+      case 2:
+        through.start();
+        break;
+      case 3:
+        through.pause();
+        typewriter.pause();
+        countdown.start();
+        setPressedWord(typewriter.text.length);
+        break;
+      case 4:
+        through.stop();
+        typewriter.stop()
+        break;
+      case 5:
+        result.open();
+    }
+  }, [scene]);
+
+  useEffect(() => {
+    if (!isTransfer) filter.open();
+    
+    setScene(0);
+    return () => setScene(0);
+  },[]);
+
+  const toFilter = (
+    workbooks?: string[], 
+    levels?: string[], 
+    keyword?: string, 
+    keywordOption?: KeywordOption,
+    perPage?: number,
+  ) => {
+    const seed = Math.floor(Math.random() * 100000);
+    setParams({ 
+      ...params, 
+      page: 1, 
+      perPage,
+      seed,
+      workbooks, 
+      levels, 
+      keyword, 
+      keywordOption
+    });
+    filter.close();
+    onFilter();
+    setNowNumber(0);
+    setScene(0);
+  }
+
+  const record = async (judgement: number) => {
+    if (judgement == 1) {
+      await axios.post('/answers', {
+        quizId: quiz?.id,
+        length: pressedWord,
+      });
+      const addId = quiz?.id
+      !!addId ? setRightList([ ...rightList, addId ]) : null;
+    }
+
+    await axios.post('/histories', {
+      quizId: quiz?.id,
+      judgement,
+    });
+  }
+
+  const judgeQuiz = (judgement: number) => {
+    record(judgement);
+    setNowNumber(nowNumber+1);
+    
+    if (nowNumber >= (size-1)) {
+      setScene(5);
+    } else { 
+      setScene(0);
+    }
+  }
+
+  const stopQuiz = async (judgement: number) => {
+    await record(judgement);
+    navigator('/');
+  }
+
+  return (
+    <>
+      { 
+        scene == 0 ? 
+          <Overlay fixed center>
+            { 
+              !quiz ? 
+                <Loader variant="dots"/> 
+              : 
+                <PracticeQuizIntro 
+                  ta="center"
+                  onFinish={delay.start}
+                />
+            }
+          </Overlay> 
+        : null
+      }
+      <PracticeResultModal
+        rightTotal={rightList.length}
+        quizzesTotal={size || 1}
+        opened={resulted}
+        onClose={result.close}
+        onRetry={() => setScene(0)}
+        onTry={filter.open}
+        onQuit={() => navigator('/')}
+      />
+      <Group position="apart">
+        <FilteringModal
+          apply={toFilter}
+          opened={filtering}
+          onOpen={filter.open}
+          onClose={!!params ? filter.close : toFilter}
+        />
+        <PracticeQuitModal
+          onJudge={(j) => stopQuiz(j)}
+        />
+      </Group>
+      <Text ta="center">
+        <Text span fz={38} fw={700} >{ nowNumber+1 }</Text> 
+        <Text span fz={18} fw={500}> / { size }</Text>
+      </Text>
+      <Card p="md" radius="lg" withBorder>
+        <PracticeTypewriteQuiz
+          question={typewriter.text}
+          visible={scene != 3}
+          time={through.time}
+          count={countdown.time}
+          countlimit={4000}
+        />
+        <PracticeQuizInfo 
+          quizId={quiz?.id}
+          answer={quiz?.answer}
+          workbook={quiz?.workbook }
+          level={quiz?.level}
+          date={quiz?.date}
+          isFavorite={quiz?.isFavorite}
+          registeredMylist={quiz?.registerdMylist}
+          visible={scene >= 4}
+        />
+      </Card>
+      <PracticeQuizController
+        canJudge={scene == 4}
+        canPress={scene == 1 || scene == 2}
+        onJudge={(j) => judgeQuiz(j)}
+        onPress={() => setScene(3)}
+        m="sm"
+      />
+    </>
+  )
+}

--- a/packages/frontend/src/components/QuizControllBar.tsx
+++ b/packages/frontend/src/components/QuizControllBar.tsx
@@ -1,9 +1,8 @@
 import { ReactNode } from "react";
-import { Grid, Group, Header, Text } from "@mantine/core";
-import { useElementSize } from "@mantine/hooks";
+import { DefaultProps, Group, Header, Stack, Text } from "@mantine/core";
+import { useResizeObserver } from "@mantine/hooks";
 
-interface QuizControllBarProps {
-  height: number,
+interface Props extends DefaultProps {
   total: number,
   buttons: ReactNode,
   pagination: ReactNode,
@@ -14,24 +13,24 @@ export default function QuizControllBar({
   total, 
   buttons, 
   pagination,
-  header = <></>
-}: QuizControllBarProps) {
-  const { ref, height } = useElementSize();
+  header = <></>,
+  ...others
+}: Props) {
+  const [ ref, rect ] = useResizeObserver();
+
   return (
     <Header
-      height={height}
+      height={rect.height + rect.y * 2}
       fixed
     >
-      <Grid px={10} pt={10} ref={ref}>
+      <Stack {...others} ref={ref} spacing={0} >
         { header }
-        <Grid.Col span={12}>
-          <Group position="apart">
-            <div>{ buttons }</div>
-            <Text ta="right">総問題数: {total}</Text>
-          </Group>
-        </Grid.Col>
+        <Group position="apart">
+          <div>{ buttons }</div>
+          <Text ta="right">総問題数: {total}</Text>
+        </Group>
         { pagination }
-      </Grid>
+      </Stack>
     </Header>
   );
 }

--- a/packages/frontend/src/components/QuizEditForm.tsx
+++ b/packages/frontend/src/components/QuizEditForm.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 import { Button, Card, DefaultProps, Grid, Group, Select, Switch, Text, Textarea } from "@mantine/core";
-import { useForm } from "@mantine/form"
+import { isNotEmpty, useForm } from "@mantine/form"
 import { useCategories, useSubCategories } from "@/hooks/useCategories";
 import { useWorkbooks } from "@/hooks/useWorkbooks";
 import { SubmitValue } from "@/types";
@@ -55,8 +55,8 @@ export default function QuizEditForm({
       workbook: initialWorkbook || "",
     },
     validate: {
-      question: (v) =>  (v == initialQuestion),
-      answer: (v) => (v == initialAnswer),
+      question: isNotEmpty(),
+      answer: isNotEmpty(),
     },
   });
 

--- a/packages/frontend/src/components/QuizList.tsx
+++ b/packages/frontend/src/components/QuizList.tsx
@@ -5,12 +5,16 @@ import { Center, Loader } from "@mantine/core";
 
 interface QuizListProps {
   quizzes?: Quiz[],
+  page: number,
+  perPage: number,
   isHidden?: boolean,
   coloring?: boolean,
 }
 
 export default function QuizList({
   quizzes,
+  page,
+  perPage,
   isHidden = false,
   coloring = false,
 }: QuizListProps) {
@@ -26,7 +30,7 @@ export default function QuizList({
         quizzes.map((quiz, idx) => (
           <QuizCard 
             key={`${idx}${isHidden}`}
-            index={idx+1}
+            index={(page -1) * perPage + idx + 1}
             quiz={quiz}
             mylists={mylists || []}
             coloring={coloring}

--- a/packages/frontend/src/components/QuizList.tsx
+++ b/packages/frontend/src/components/QuizList.tsx
@@ -1,9 +1,10 @@
 import { Quiz } from "@/types"
-import { useMylistInfomations } from "@/hooks/useMylists";
+import { useMylists } from "@/hooks/useMylists";
 import QuizCard from "./QuizCard"
+import { Center, Loader } from "@mantine/core";
 
 interface QuizListProps {
-  quizzes: Quiz[],
+  quizzes?: Quiz[],
   isHidden?: boolean,
   coloring?: boolean,
 }
@@ -13,21 +14,34 @@ export default function QuizList({
   isHidden = false,
   coloring = false,
 }: QuizListProps) {
-  const { mylists } = useMylistInfomations();
+  const { mylists } = useMylists();
 
   return (
     <>
-      {quizzes?.map((quiz, idx) => (
-        <QuizCard 
-          key={`${idx}${isHidden}`}
-          index={idx+1}
-          quiz={quiz}
-          mylists={mylists || []}
-          coloring={coloring}
-          isHidden={isHidden}
-          mb={10}
-        />
-      ))}
+    {
+      !!quizzes 
+      ?
+      <>
+      {
+        quizzes.map((quiz, idx) => (
+          <QuizCard 
+            key={`${idx}${isHidden}`}
+            index={idx+1}
+            quiz={quiz}
+            mylists={mylists || []}
+            coloring={coloring}
+            isHidden={isHidden}
+            mb={10}
+          />
+        ))
+      }
+      { quizzes.length == 0 ? <Center>No data</Center> : null }
+      </>
+      : 
+      <Center>
+        <Loader variant="dots"/>
+      </Center>
+    }
     </>
   )
 }

--- a/packages/frontend/src/components/QuizMylistButton.tsx
+++ b/packages/frontend/src/components/QuizMylistButton.tsx
@@ -40,7 +40,7 @@ export default function QuizMylistButton({
 
     await axios.put('/mylists/quiz', {
       quizId,
-      MIDIConnectionEvent: newMyList.mid,
+      mid: newMyList.mid,
     })
   }
 

--- a/packages/frontend/src/components/QuizTransfarButton.tsx
+++ b/packages/frontend/src/components/QuizTransfarButton.tsx
@@ -1,0 +1,42 @@
+import { useIsMobile } from "@/contexts/isMobile";
+import { ActionIcon, Button, DefaultProps } from "@mantine/core";
+import { IconArrowAutofitContent } from "@tabler/icons-react";
+
+interface Props extends DefaultProps {
+  apply: () => void
+}
+
+export default function({
+  apply,
+  ...others
+}: Props) {
+  const isMobile = useIsMobile();
+  const Icon = () => <IconArrowAutofitContent/>;
+  const color = "green"
+
+  const DefaultButton = () => (
+    <Button
+      onClick={() => apply()}
+      leftIcon={<Icon/>}
+      variant="outline"
+      color={color}
+      { ...others }
+    >Transfar</Button>
+  );
+
+  const MobileButton = () => (
+    <ActionIcon
+      onClick={() => apply()}
+      size="lg" 
+      radius="xl" 
+      variant="outline"
+      color={color}
+    >
+      <Icon/>
+    </ActionIcon>
+  )
+
+  return (
+    isMobile ? <MobileButton/> : <DefaultButton />
+  )
+}

--- a/packages/frontend/src/components/QuizViewer.tsx
+++ b/packages/frontend/src/components/QuizViewer.tsx
@@ -12,6 +12,8 @@ import useQuizzes from '@/hooks/useQuizzes';
 import { useHistories } from "@/hooks/useHistories";
 import HistorySelectJudgement from './HistorySelectJudgement';
 import HistoryDateRange from './HistoryDateRange';
+import QuizTransfarButton from './QuizTransfarButton';
+import { useNavigate } from 'react-router-dom';
 
 interface Props {
   path?: string,
@@ -33,6 +35,7 @@ export default function({
     dayjs().startOf('day').valueOf(),
     dayjs().endOf('day').valueOf(),
   ]);
+  const navigate = useNavigate();
   const { quizzes, params, setParams } = useQuizzes(path, initialParams);
   const { histories } = useHistories(dates[0], dates[1]);
   const right = !!histories ? Number(histories.right) : 0;
@@ -79,6 +82,10 @@ export default function({
     setParams({...params, page});
   }
 
+  const toTransfar = () => {
+    navigate(`/practice?path=/${path}`);
+  }
+
   const changeJudgement = (
     judgements: Judgement[]
   ) => {
@@ -118,6 +125,9 @@ export default function({
               isHidden={isHidden}
               onToggle={setIsHidden}
             />
+            <QuizTransfarButton
+              apply={toTransfar}
+            />
           </Group>
         }
         pagination={
@@ -141,7 +151,7 @@ export default function({
               </Center>
             </>
             : null}
-            <Center mt="xs">
+            <Center mt="sm">
               <QuizPagination
                 page={activePage}
                 total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}

--- a/packages/frontend/src/components/QuizViewer.tsx
+++ b/packages/frontend/src/components/QuizViewer.tsx
@@ -164,6 +164,7 @@ export default function({
       <QuizList
         quizzes={quizzes}
         isHidden={isHidden}
+        coloring={isHistory}
       />  
     </>
   )

--- a/packages/frontend/src/components/QuizViewer.tsx
+++ b/packages/frontend/src/components/QuizViewer.tsx
@@ -1,0 +1,160 @@
+import { ReactNode, useState } from 'react';
+import { Center, Group, Stack, } from '@mantine/core';
+import dayjs from "@/plugins/dayjs";
+import QuizList from '@/components/QuizList';
+import QuizControllBar from '@/components/QuizControllBar';
+import FilteringModal from '@/components/FilteringModal';
+import QuizPagination from '@/components/QuizPagination';
+import QuizShuffleButton from '@/components/QuizShuffleButton';
+import QuizHiddenAnswerButton from '@/components/QuizHiddenAnswerButton';
+import { Judgement, KeywordOption, QuizRequestParams } from '@/types';
+import useQuizzes from '@/hooks/useQuizzes';
+import { useHistories } from "@/hooks/useHistories";
+import HistorySelectJudgement from './HistorySelectJudgement';
+import HistoryDateRange from './HistoryDateRange';
+
+interface Props {
+  path?: string,
+  headerCard?: ReactNode,
+  isHistory?: boolean,
+  initialParams?: QuizRequestParams,
+}
+
+export default function({
+  path = '',
+  initialParams = { perPage: 100 },
+  headerCard = <></>,
+  isHistory = false,
+}: Props) {
+  const [ activePage, setPage ] = useState(1);
+  const [ isHidden, setIsHidden ] = useState(false);
+  const [ judgements, setJudgements ] = useState<Judgement[]>([]);
+  const [ dates, setDates ] = useState<number[]>([ 
+    dayjs().startOf('day').valueOf(),
+    dayjs().endOf('day').valueOf(),
+  ]);
+  const { quizzes, params, setParams } = useQuizzes(path, initialParams);
+  const { histories } = useHistories(dates[0], dates[1]);
+  const right = !!histories ? Number(histories.right) : 0;
+  const wrong = !!histories ? Number(histories.wrong) : 0;
+  const through = !!histories ? Number(histories.through) : 0;
+
+  const size = !!quizzes && !!quizzes.length ? quizzes[0].size : 0;
+
+  const toFilter = (
+    workbooks?: string[], 
+    levels?: string[], 
+    keyword?: string, 
+    keywordOption?: KeywordOption,
+    perPage?: number,
+  ) => {
+    setPage(1);
+    setParams({ 
+      ...params, 
+      page: 1, 
+      seed: undefined,
+      perPage,
+      workbooks, 
+      levels, 
+      keyword, 
+      keywordOption,
+    });
+  }
+
+  const toShuffle = (
+    seed: number
+  ) => {
+    setPage(1);
+    setParams({
+      ...params,
+      page: 1,
+      seed
+    });
+  }
+
+  const changePage = (
+    page: number
+  ) => {
+    setPage(page);
+    setParams({...params, page});
+  }
+
+  const changeJudgement = (
+    judgements: Judgement[]
+  ) => {
+    setJudgements(judgements)
+    setParams({
+      ...params,
+      judgements
+    })
+  }
+
+  const changeDates = (
+    dates: number[],
+  ) => {
+    setDates(dates);
+    setParams({
+      ...params,
+      since: dates[0],
+      until: dates[1]
+    })
+  }
+
+  return (
+    <>
+      <QuizControllBar
+        p="sm"
+        total={size}
+        header={headerCard}
+        buttons={
+          <Group>
+            <FilteringModal
+              apply={toFilter}
+            />
+            <QuizShuffleButton
+              apply={toShuffle}
+            />
+            <QuizHiddenAnswerButton
+              isHidden={isHidden}
+              onToggle={setIsHidden}
+            />
+          </Group>
+        }
+        pagination={
+          <Stack spacing={2}>
+            {isHistory ? 
+            <>
+              <Center mt={0}>
+                <HistorySelectJudgement
+                  judgements={judgements}
+                  right={right}
+                  wrong={wrong}
+                  throgh={through}
+                  onSelect={changeJudgement}
+                />
+              </Center>
+              <Center mt={0}>
+                <HistoryDateRange
+                  dates={dates}
+                  onChangeDates={changeDates}
+                />
+              </Center>
+            </>
+            : null}
+            <Center mt="xs">
+              <QuizPagination
+                page={activePage}
+                total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}
+                setPage={changePage}
+              />
+            </Center>
+          </Stack>
+        }
+      />
+      <QuizList
+        quizzes={quizzes}
+        isHidden={isHidden}
+      />  
+    </>
+  )
+}

--- a/packages/frontend/src/components/QuizViewer.tsx
+++ b/packages/frontend/src/components/QuizViewer.tsx
@@ -1,4 +1,5 @@
 import { ReactNode, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Center, Group, Stack, } from '@mantine/core';
 import dayjs from "@/plugins/dayjs";
 import QuizList from '@/components/QuizList';
@@ -13,7 +14,6 @@ import { useHistories } from "@/hooks/useHistories";
 import HistorySelectJudgement from './HistorySelectJudgement';
 import HistoryDateRange from './HistoryDateRange';
 import QuizTransfarButton from './QuizTransfarButton';
-import { useNavigate } from 'react-router-dom';
 
 interface Props {
   path?: string,
@@ -163,6 +163,8 @@ export default function({
       />
       <QuizList
         quizzes={quizzes}
+        page={activePage}
+        perPage={params?.perPage || 0}
         isHidden={isHidden}
         coloring={isHistory}
       />  

--- a/packages/frontend/src/components/QuizWorkbookBadge.tsx
+++ b/packages/frontend/src/components/QuizWorkbookBadge.tsx
@@ -4,25 +4,29 @@ import { useIsMobile } from "@/contexts/isMobile";
 interface Props extends BadgeProps {
   workbookName: string,
   levelColor: string,
-  date: string,
+  date?: string,
+  transformUpper?: boolean,
 }
 
 export function QuizWorkbookBadge({
   workbookName,
   levelColor,
   date,
+  transformUpper,
   ...other
 }: Props) {
   const isMobile = useIsMobile();
 
   return (
     <Badge 
+      variant="dot"
       color={levelColor} 
       radius="sm"
       size={ isMobile ? "md" : "lg" }
+      sx={{ textTransform: 'none', backgroundColor: '#fff' }}
       {...other}
     >
-      {workbookName}{!!date ? `(${date.slice(0, 4)})` : null}
+      <div>{workbookName}{!!date ? `(${date.slice(0, 4)})` : null}</div>
     </Badge>
   )
 }

--- a/packages/frontend/src/hooks/useMylists.ts
+++ b/packages/frontend/src/hooks/useMylists.ts
@@ -4,7 +4,7 @@ import { MylistInformation } from '../types';
 
 const fetcher = (url: string) => axios.get<MylistInformation[]>(url).then(res => res.data); 
 
-export const useMylistInfomations = (shouldFetch = true) => {
+export const useMylists = (shouldFetch = true) => {
   const { data: mylists, isLoading, error, mutate } = useSWR(
     shouldFetch ? '/mylists' : null, 
   fetcher);

--- a/packages/frontend/src/hooks/useQuizzes.ts
+++ b/packages/frontend/src/hooks/useQuizzes.ts
@@ -50,12 +50,12 @@ const createFilter = ({
 }
 
 const useQuizzes = (
-  initalParams: QuizRequestParams = { perPage: 100 },
   path = '',
+  initialParams: QuizRequestParams = { perPage: 100 },
   shouldFetch = true,
 ) => {
-  const { data: params, mutate: setParams } = useSWR<QuizRequestParams>('params', null, { fallbackData: initalParams});
-  const filter = createFilter(params || {}).toString()
+  const { data: params, mutate: setParams } = useSWR<QuizRequestParams>('params', null, { fallbackData: initialParams});
+  const filter = createFilter(params || {}).toString();
 
   const { data: quizzes, isLoading, error, mutate } = useSWR(
     shouldFetch ? [`/quizzes${path}`, filter ] : null,

--- a/packages/frontend/src/layouts/default.tsx
+++ b/packages/frontend/src/layouts/default.tsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 import { useDisclosure } from "@mantine/hooks";
 import { notifications } from "@mantine/notifications";
 import UserLogoutButton from "../components/UserLogoutButton";
-import { useMylistInfomations } from "../hooks/useMylists";
+import { useMylists } from "../hooks/useMylists";
 import Logo from "../components/Logo";
 import { checkAuth } from "../plugins/auth";
 import { useWorkbooks } from "@/hooks/useWorkbooks";
@@ -31,7 +31,7 @@ export default function DefaultLayout() {
   const [opened, { open, close }] = useDisclosure(false);
   const navigate = useNavigate();
   const location = useLocation();
-  const { mylists } = useMylistInfomations(!loading);
+  const { mylists } = useMylists(!loading);
   const { workbooks } = useWorkbooks(!loading);
   const isMobile = useIsMobile();
 

--- a/packages/frontend/src/pages/favorite.tsx
+++ b/packages/frontend/src/pages/favorite.tsx
@@ -1,103 +1,19 @@
-import QuizList from '@/components/QuizList'
-import QuizControllBar from '@/components/QuizControllBar'
-import useQuizzes from '@/hooks/useQuizzes'
-import { Center, Grid, Group, Loader } from '@mantine/core'
-import FilteringModal from '@/components/FilteringModal'
-import { KeywordOption } from '@/types'
-import { useState } from 'react'
-import QuizPagination from '@/components/QuizPagination'
-import QuizShuffleButton from '@/components/QuizShuffleButton'
-import QuizHiddenAnswerButton from '@/components/QuizHiddenAnswerButton'
+import { useEffect } from 'react';
+import QuizViewer from '@/components/QuizViewer'
+import useQuizzes from '@/hooks/useQuizzes';
 
 export default function Search() {
-  const [ activePage, setPage ] = useState(1);
-  const [ isHidden, setIsHidden ] = useState(false);
-  const { quizzes, params, setParams } = useQuizzes({ perPage: 100 }, '/favorite')
+  const { setParams } = useQuizzes();
 
-  const size = !!quizzes && !!quizzes.length ? quizzes[0].size : 0
-
-  const toFilter = (
-    workbooks?: string[], 
-    levels?: string[], 
-    keyword?: string, 
-    keywordOption?: KeywordOption,
-    perPage?: number,
-  ) => {
-    setPage(1)
-    setParams({ 
-      ...params, 
-      page: 1, 
-      seed: undefined,
-      perPage,
-      workbooks, 
-      levels, 
-      keyword, 
-      keywordOption,
-    })
-  }
-
-  const toShuffle = (
-    seed: number
-  ) => {
-    setPage(1)
-    setParams({
-      ...params,
-      page: 1,
-      seed
-    })
-  }
-
-  const changePage = (
-    page: number
-  ) => {
-    setPage(page)
-    setParams({...params, page})
-  }
+  useEffect(() => {
+    setParams({ perPage: 100 })
+  }, []); 
 
   return (
     <>
-      <QuizControllBar
-        height={!!quizzes ? 110 : 60}
-        total={size}
-        buttons={
-          <Group>
-            <FilteringModal
-              apply={toFilter}
-            />
-            <QuizShuffleButton
-              apply={toShuffle}
-            />
-            <QuizHiddenAnswerButton
-              isHidden={isHidden}
-              onToggle={setIsHidden}
-            />
-          </Group>
-        }
-        pagination={
-          <Grid.Col mb={5}>
-            <Center>
-              <QuizPagination
-                page={activePage}
-                total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}
-                setPage={changePage}
-              />
-            </Center>
-          </Grid.Col>
-        }
+      <QuizViewer
+        path="/favorite"
       />
-      {!!quizzes ? 
-        quizzes.length !== 0 ? 
-        <QuizList
-          quizzes={quizzes}
-          isHidden={isHidden}
-        />
-        :
-        <Center>No data</Center>  
-      : 
-        <Center>
-          <Loader variant="dots"/>
-        </Center>
-      }
     </>
   )
 }

--- a/packages/frontend/src/pages/history.tsx
+++ b/packages/frontend/src/pages/history.tsx
@@ -1,158 +1,25 @@
-import { useState } from "react"
-import { Center, Grid, Group, Loader } from "@mantine/core";
-import { Judgement, KeywordOption } from "@/types"
+import { useEffect } from "react";
+import QuizViewer from '@/components/QuizViewer';
 import useQuizzes from "@/hooks/useQuizzes";
-import QuizControllBar from "@/components/QuizControllBar";
-import FilteringModal from "@/components/FilteringModal";
-import QuizShuffleButton from "@/components/QuizShuffleButton";
-import QuizPagination from "@/components/QuizPagination";
-import QuizList from "@/components/QuizList";
-import HistorySelectJudgement from "@/components/HistorySelectJudgement";
-import HistoryDateRange from "@/components/HistoryDateRange";
 import dayjs from "@/plugins/dayjs";
-import { useHistories } from "@/hooks/useHistories";
-import QuizHiddenAnswerButton from "@/components/QuizHiddenAnswerButton";
  
 export default function History() {
-  const [ activePage, setPage ] = useState(1);
-  const [ judgements, setJudgements ] = useState<Judgement[]>([]);
-  const [ dates, setDates ] = useState<number[]>([ 
+  const { setParams } = useQuizzes();
+  const dates = [
     dayjs().startOf('day').valueOf(),
     dayjs().endOf('day').valueOf(),
-  ]);
-  const { quizzes, params, setParams } = useQuizzes({ perPage: 100, since: dates[0], until: dates[1] }, '/history');
-  const { histories } = useHistories(dates[0], dates[1]);
-  const [ isHidden, setIsHidden ] = useState(false);
-  const size = !!quizzes && quizzes.length !== 0 ? quizzes[0].size : 0;
-  const right = !!histories ? Number(histories.right) : 0;
-  const wrong = !!histories ? Number(histories.wrong) : 0;
-  const through = !!histories ? Number(histories.through) : 0;
-  
-  const toFilter = (
-    workbooks?: string[], 
-    levels?: string[], 
-    keyword?: string, 
-    keywordOption?: KeywordOption,
-    perPage?: number,
-  ) => {
-    setPage(1);
-    setParams({ 
-      ...params, 
-      page: 1, 
-      seed: undefined,
-      perPage,
-      workbooks, 
-      levels, 
-      keyword, 
-      keywordOption,
-    });
-  }
+  ];
 
-  const toShuffle = (
-    seed: number
-  ) => {
-    setPage(1);
-    setParams({
-      ...params,
-      page: 1,
-      seed,
-    });
-  }
-
-  const changePage = (
-    page: number
-  ) => {
-    setPage(page)
-    setParams({...params, page});
-  }
-
-  const changeJudgement = (
-    judgements: Judgement[]
-  ) => {
-    setJudgements(judgements)
-    setParams({
-      ...params,
-      judgements
-    })
-  }
-
-  const changeDates = (
-    dates: number[],
-  ) => {
-    setDates(dates);
-    setParams({
-      ...params,
-      since: dates[0],
-      until: dates[1]
-    })
-  }
+  useEffect(() => {
+    setParams({ perPage: 100, since: dates[0], until: dates[1] })
+  }, []);
 
   return (
     <>
-      <QuizControllBar
-        height={!!quizzes && quizzes.length != 0 ? 180 : 140}
-        total={size}
-        buttons={
-          <Group>
-            <FilteringModal
-              apply={toFilter}
-            />
-            <QuizShuffleButton
-              apply={toShuffle}
-            />
-            <QuizHiddenAnswerButton
-              isHidden={isHidden}
-              onToggle={setIsHidden}
-            />
-          </Group>
-        }
-        pagination={
-          <>
-            <Grid.Col span={12} p={0}>
-              <Center mt={0}>
-                <HistorySelectJudgement
-                  judgements={judgements}
-                  right={right}
-                  wrong={wrong}
-                  throgh={through}
-                  onSelect={changeJudgement}
-                />
-              </Center>
-            </Grid.Col>
-            <Grid.Col span={12} p={0}>
-              <Center mt={0}>
-                <HistoryDateRange
-                  dates={dates}
-                  onChangeDates={changeDates}
-                />
-              </Center>
-            </Grid.Col>
-            <Grid.Col span={12} mb={5}>
-              <Center>
-                <QuizPagination
-                  page={activePage}
-                  total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}
-                  setPage={changePage}
-                />
-              </Center>
-            </Grid.Col>
-          </>
-        }
+      <QuizViewer
+        path="/history" 
+        isHistory
       />
-      {!!quizzes ? 
-        <>
-          <QuizList
-            quizzes={quizzes}
-            isHidden={isHidden}
-            coloring
-          />
-          { quizzes.length == 0 ? <Center>No data</Center> : null }
-        </>
-      : 
-        <Center>
-          <Loader variant="dots"/>
-        </Center>
-      }
     </>
   )
 }

--- a/packages/frontend/src/pages/mylists.tsx
+++ b/packages/frontend/src/pages/mylists.tsx
@@ -1,76 +1,30 @@
-import { useEffect, useState } from "react";
+import { useEffect } from 'react';
 import { useNavigate, useParams } from "react-router-dom";
-import { Card, Center, Grid, Group, Loader, Text } from "@mantine/core";
-import QuizControllBar from "../components/QuizControllBar";
-import FilteringModal from "../components/FilteringModal";
-import QuizShuffleButton from "../components/QuizShuffleButton";
-import QuizPagination from "../components/QuizPagination";
-import QuizList from "../components/QuizList";
-import { KeywordOption, MylistInformation } from "../types";
-import useQuizzes from "../hooks/useQuizzes";
-import { useMylistInfomations } from "../hooks/useMylists";
-import MylistDeleteModal from "../components/MylistDeleteModal";
-import MylistEditModal from "../components/MylistEditModal";
-import { useInput } from "../hooks";
-import axios from "../plugins/axios";
+import { Card, Group, Text } from "@mantine/core";
+import MylistDeleteModal from "@/components/MylistDeleteModal";
+import MylistEditModal from "@/components/MylistEditModal";
+import QuizViewer from "@/components/QuizViewer";
+import { useInput } from "@/hooks";
+import useQuizzes from "@/hooks/useQuizzes";
+import { useMylists } from "@/hooks/useMylists";
+import axios from "@/plugins/axios";
+import { MylistInformation } from "@/types";
 
 export default function Mylist(){
-  const pageParams = useParams();
+  const { setParams } = useQuizzes('/mylist')
+  const { mid } = useParams();
   const navigator = useNavigate();
-  const mid = pageParams.mid;
-  const [ activePage, setPage ] = useState(1);
-  const { quizzes, params, setParams } = useQuizzes({ perPage: 100, mid: mid }, `/mylist`);
-  const { mylists, mutate } = useMylistInfomations();
+  const { mylists, mutate } = useMylists();
 
-  const size = !!quizzes && quizzes.length !== 0 ? quizzes[0].size : 0;
   const mylistName = mylists?.find(list => list.mid == mid)?.name;
-
   const [ newNameProps ] = useInput(mylistName || '');
 
   useEffect(() => {
     setParams({
-      ...params,
-      mid
-    })
+      mid,
+      perPage: 100,
+    });
   }, [mid]);
-
-  const toFilter = (
-    workbooks?: string[], 
-    levels?: string[], 
-    keyword?: string, 
-    keywordOption?: KeywordOption,
-    perPage?: number,
-  ) => {
-    setPage(1)
-    setParams({ 
-      ...params, 
-      page: 1, 
-      seed: undefined,
-      perPage,
-      workbooks, 
-      levels, 
-      keyword, 
-      keywordOption,
-    })
-  }
-
-  const toShuffle = (
-    seed: number
-  ) => {
-    setPage(1)
-    setParams({
-      ...params,
-      page: 1,
-      seed
-    })
-  }
-
-  const changePage = (
-    page: number
-  ) => {
-    setPage(page)
-    setParams({...params, page})
-  }
 
   const toEdit = async () => {
     const newlist = await axios.put<MylistInformation[]>('/mylists/rename', {
@@ -90,70 +44,38 @@ export default function Mylist(){
     mutate(newlist);
   }
 
+  const MylistCard = () => (
+    <Card 
+      mb="xs"
+      w="100%" 
+      withBorder
+      sx={(theme) => ({
+        backgroundImage: theme.fn.gradient(),
+        color: theme.white,
+      })}
+    >
+      <Group position="apart">
+        <Text weight={700} size={25}>{ mylistName }</Text>
+        <Group spacing="md">
+          <MylistEditModal
+            newNameProps={newNameProps}
+            onSave={toEdit}
+          />
+          <MylistDeleteModal
+            onDelete={toDelete}
+          />
+        </Group>
+      </Group>
+    </Card>
+  )
+
   return (
     <>
-      <QuizControllBar
-        height={!!quizzes ? 190 : 140}
-        total={size}
-        header={
-          <Card 
-            m={7} 
-            w="100%" 
-            withBorder
-            sx={(theme) => ({
-              backgroundImage: theme.fn.gradient(),
-              color: theme.white,
-            })}
-          >
-            <Group position="apart">
-              <Text weight={700} size={25}>{ mylistName }</Text>
-              <Group spacing="md">
-                <MylistEditModal
-                  newNameProps={newNameProps}
-                  onSave={toEdit}
-                />
-                <MylistDeleteModal
-                  onDelete={toDelete}
-                />
-              </Group>
-                
-            </Group>
-          </Card>
-        }
-        buttons={
-          <Group>
-            <FilteringModal
-              apply={toFilter}
-            />
-            <QuizShuffleButton
-              apply={toShuffle}
-            />
-          </Group>
-        }
-        pagination={
-          <Grid.Col span={12} mb="xs">
-            <Center>
-              <QuizPagination
-                page={activePage}
-                total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}
-                setPage={changePage}
-              />
-            </Center>
-          </Grid.Col>
-        }
+      <QuizViewer 
+        key={mid} 
+        path='/mylist'
+        headerCard={<MylistCard/>}
       />
-      {!!quizzes ? 
-        quizzes.length !== 0 ? 
-        <QuizList
-          quizzes={quizzes}
-        />
-        :
-        <Center>No data</Center>   
-      : 
-        <Center>
-          <Loader variant="dots"/>
-        </Center>
-      }
     </>
   )
 }

--- a/packages/frontend/src/pages/practice.tsx
+++ b/packages/frontend/src/pages/practice.tsx
@@ -21,7 +21,7 @@ export default function Practice() {
   const [ scene, setScene ] = useState(0);
   const [ filtering, filter ] = useDisclosure(false);
   const [ resulted, result ] = useDisclosure(false);
-  const { quizzes, params, setParams } = useQuizzes(undefined, '', shouldFetch);
+  const { quizzes, params, setParams } = useQuizzes('', undefined, shouldFetch);
   const [ rightList, setRightList ] = useState<number[]>([]);
   const [ pressedWord, setPressedWord ] = useState(0);
   const navigator = useNavigate();

--- a/packages/frontend/src/pages/practice.tsx
+++ b/packages/frontend/src/pages/practice.tsx
@@ -1,197 +1,37 @@
-import { useEffect, useState } from "react";
-import { Card, Group, Loader, Overlay, Text } from "@mantine/core";
-import PracticeTypewriteQuiz from "../components/PracticeTypewriteQuiz";
-import useQuizzes from "../hooks/useQuizzes";
-import { KeywordOption } from "../types";
-import FilteringModal from "../components/FilteringModal";
-import { useTimer, useTypewriter } from "../hooks";
-import { useDisclosure } from "@mantine/hooks";
-import { PracticeQuizIntro } from "../components/PracticeQuizIntro";
-import { PracticeQuizInfo } from "../components/PracticeQuizInfo";
-import { PracticeQuizController } from "../components/PracticeQuizController";
-import axios from "../plugins/axios";
-import PracticeQuitModal from "../components/PracticeQuitModal";
-import { useNavigate } from "react-router-dom";
-import PracticeResultModal  from "../components/PracticeResultModal";
+import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import PracticeSceneChanger from "@/components/PracticeSceneChanger";
+import useQuizzes from "@/hooks/useQuizzes";
+
+function shuffleSequense(n: number) {
+  const a = [ ...Array(n).keys() ];
+
+  for(let i = a.length -1; i > 0; i--){
+    const j = Math.floor(Math.random() * (i + 1));
+    const tmp = a[i];
+    a[i] = a[j];
+    a[j] = tmp;
+  }
+
+  return a;
+}
 
 export default function Practice() {
-  // const [ params, setParams ] = useState<QuizRequestParams | null>(null);
-  const [ nowNumber, setNowNumber ] = useState(0);
+  const [ searchParams ] = useSearchParams();
   const [ shouldFetch, setShouldFetch ] = useState(false);
-  const [ scene, setScene ] = useState(0);
-  const [ filtering, filter ] = useDisclosure(false);
-  const [ resulted, result ] = useDisclosure(false);
-  const { quizzes, params, setParams } = useQuizzes('', undefined, shouldFetch);
-  const [ rightList, setRightList ] = useState<number[]>([]);
-  const [ pressedWord, setPressedWord ] = useState(0);
-  const navigator = useNavigate();
+  const path = searchParams.get('path');
+  const isTransfer = !!path;
 
-  const size = !!quizzes ? quizzes.length : 0;
-  const quiz = !!quizzes ? quizzes[nowNumber] : null;
-
-  const delay = useTimer(500, 100, () => setScene(1)); 
-  const typewriter = useTypewriter(quiz?.question || "", 100, () => setScene(2));
-  const countdown = useTimer(4000, 1000, () => setScene(4)); 
-  const through = useTimer(3000, 100, () => setScene(4)); 
-
-  useEffect(() => {
-    switch(scene) {
-      case 0: 
-        delay.reset();
-        typewriter.reset();
-        countdown.reset();
-        through.reset();
-        result.close();
-        break;
-      case 1:
-        typewriter.start();
-        break;
-      case 2:
-        through.start();
-        break;
-      case 3:
-        through.pause();
-        typewriter.pause();
-        countdown.start();
-        setPressedWord(typewriter.text.length);
-        break;
-      case 4:
-        through.stop();
-        typewriter.stop()
-        break;
-      case 5:
-        result.open();
-    }
-  }, [scene]);
-  
-  useEffect(() => {
-    filter.open();
-    setScene(0);
-    return () => setScene(0);
-  },[]);
-
-  const toFilter = (
-    workbooks?: string[], 
-    levels?: string[], 
-    keyword?: string, 
-    keywordOption?: KeywordOption,
-    perPage?: number,
-  ) => {
-    const seed = Math.floor(Math.random() * 100000);
-    setParams({ 
-      ...params, 
-      page: 1, 
-      perPage,
-      seed,
-      workbooks, 
-      levels, 
-      keyword, 
-      keywordOption
-    });
-    filter.close();
-    setShouldFetch(true);
-    setNowNumber(0);
-    setScene(0);
-  }
-
-  const record = async (judgement: number) => {
-    if (judgement == 1) {
-      await axios.post('/answers', {
-        quizId: quiz?.id,
-        length: pressedWord,
-      });
-      const addId = quiz?.id
-      !!addId ? setRightList([ ...rightList, addId ]) : null;
-    }
-
-    await axios.post('/histories', {
-      quizId: quiz?.id,
-      judgement,
-    });
-  }
-
-  const judgeQuiz = (judgement: number) => {
-    record(judgement);
-    setNowNumber(nowNumber+1);
-    
-    if (nowNumber >= (size-1)) {
-      setScene(5);
-    } else { 
-      setScene(0);
-    }
-  }
-
-  const stopQuiz = async (judgement: number) => {
-    await record(judgement);
-    navigator('/');
-  }
+  const { quizzes } = useQuizzes(isTransfer ? `/${path}` : undefined, undefined, shouldFetch || isTransfer);
+  const shuffledList = isTransfer ? shuffleSequense(quizzes?.length || 0) : [...Array(quizzes?.length || 0).keys()];
 
   return (
     <>
-      { 
-        scene == 0 ? 
-          <Overlay fixed center>
-            { 
-              !quiz ? 
-                <Loader variant="dots"/> 
-              : 
-                <PracticeQuizIntro 
-                  ta="center"
-                  onFinish={delay.start}
-                />
-            }
-          </Overlay> 
-        : null
-      }
-      <PracticeResultModal
-        rightTotal={rightList.length}
-        quizzesTotal={quizzes?.length || 1}
-        opened={resulted}
-        onClose={result.close}
-        onRetry={() => setScene(0)}
-        onTry={filter.open}
-        onQuit={() => navigator('/')}
-      />
-      <Group position="apart">
-        <FilteringModal
-          apply={toFilter}
-          opened={filtering}
-          onOpen={filter.open}
-          onClose={!!params ? filter.close : toFilter}
-        />
-        <PracticeQuitModal
-          onJudge={(j) => stopQuiz(j)}
-        />
-      </Group>
-      <Text ta="center">
-        <Text span fz={38} fw={700} >{ nowNumber+1 }</Text> 
-        <Text span fz={18} fw={500}> / { size }</Text>
-      </Text>
-      <Card p="md" radius="lg" withBorder>
-        <PracticeTypewriteQuiz
-          question={typewriter.text}
-          visible={scene != 3}
-          time={through.time}
-          count={countdown.time}
-          countlimit={4000}
-        />
-        <PracticeQuizInfo 
-          quizId={quiz?.id}
-          answer={quiz?.answer}
-          workbook={quiz?.workbook }
-          level={quiz?.level}
-          date={quiz?.date}
-          isFavorite={quiz?.isFavorite}
-          registeredMylist={quiz?.registerdMylist}
-          visible={scene >= 4}
-        />
-      </Card>
-      <PracticeQuizController
-        canJudge={scene == 4}
-        canPress={scene == 1 || scene == 2}
-        onJudge={(j) => judgeQuiz(j)}
-        onPress={() => setScene(3)}
-        m="sm"
+      <PracticeSceneChanger
+        quizzes={quizzes}
+        shuffledList={shuffledList}
+        isTransfer={isTransfer}
+        onFilter={() => setShouldFetch(true)}
       />
     </>
   )

--- a/packages/frontend/src/pages/search.tsx
+++ b/packages/frontend/src/pages/search.tsx
@@ -1,103 +1,17 @@
-import QuizList from '../components/QuizList'
-import QuizControllBar from '../components/QuizControllBar'
-import useQuizzes from '../hooks/useQuizzes'
-import { Center, Grid, Group, Loader } from '@mantine/core'
-import FilteringModal from '../components/FilteringModal'
-import { KeywordOption } from '../types'
-import { useState } from 'react'
-import QuizPagination from '../components/QuizPagination'
-import QuizShuffleButton from '../components/QuizShuffleButton'
-import QuizHiddenAnswerButton from '../components/QuizHiddenAnswerButton'
+import { useEffect } from 'react';
+import QuizViewer from '@/components/QuizViewer';
+import useQuizzes from '@/hooks/useQuizzes';
 
 export default function Search() {
-  const [activePage, setPage] = useState(1);
-  const [ isHidden, setIsHidden ] = useState(false);
-  const { quizzes, params, setParams } = useQuizzes()
-
-  const size = !!quizzes && !!quizzes.length ? quizzes[0].size : 0
-
-  const toFilter = (
-    workbooks?: string[], 
-    levels?: string[], 
-    keyword?: string, 
-    keywordOption?: KeywordOption,
-    perPage?: number,
-  ) => {
-    setPage(1)
-    setParams({ 
-      ...params, 
-      page: 1, 
-      seed: undefined,
-      perPage,
-      workbooks, 
-      levels, 
-      keyword, 
-      keywordOption,
-    })
-  }
-
-  const toShuffle = (
-    seed: number
-  ) => {
-    setPage(1)
-    setParams({
-      ...params,
-      page: 1,
-      seed
-    })
-  }
-
-  const changePage = (
-    page: number
-  ) => {
-    setPage(page)
-    setParams({...params, page})
-  }
+  const { setParams } = useQuizzes();
+  
+  useEffect(() => {
+    setParams({ perPage: 100 })
+  }, []);
 
   return (
     <>
-      <QuizControllBar
-        height={!!quizzes ? 110 : 60}
-        total={size}
-        buttons={
-          <Group>
-            <FilteringModal
-              apply={toFilter}
-            />
-            <QuizShuffleButton
-              apply={toShuffle}
-            />
-            <QuizHiddenAnswerButton
-              isHidden={isHidden}
-              onToggle={setIsHidden}
-            />
-          </Group>
-        }
-        pagination={
-          <Grid.Col mb={5}>
-            <Center>
-              <QuizPagination
-                page={activePage}
-                total={!!params?.perPage ? Math.ceil(size / params.perPage) : 0}
-                setPage={changePage}
-              />
-            </Center>
-          </Grid.Col>
-        }
-      />
-      {!!quizzes ? 
-        <>
-          <QuizList
-            quizzes={quizzes}
-            isHidden={isHidden}
-          /> 
-          { quizzes.length == 0 ? <Center>No data</Center> : null }
-        </>
-      : 
-        <Center>
-          <Loader variant="dots"/>
-        </Center>
-      }
+      <QuizViewer />
     </>
   )
 }


### PR DESCRIPTION
### New Features
- Search/Favorite/History/Mylist/Createなどで表示した問題群をPracticeに転送する機能を追加
- Practiceにおいて，同じ検索条件で次の問題群を演習できる機能を追加

### Changes
#### FrontEnd
- スルー時にスルーボタンしか押せないように制限
- HistoryのQuizの並び順を練習日時順に変更
- WorkbookBadgeでTextがUppearCaseにならないように変更

### Fix Bugs
#### FrontEnd
- filteringでの検索条件がSearch/Favorite/History/Mylist/Createで共有される問題を修正
- PracticeでのModalが中心からずれる問題を修正
- QuizListのNo. が正しく表示していない問題を修正
- Quizを編集してもEditできないときがある問題を修正
- CreateのNestedLinkで少ししかLinkがない場合に空欄が表示される問題を修正

#### BackEnd
- mylistへのクイズの追加や削除ができない問題を修正